### PR TITLE
Add optional space after comma in FunctionCallArgs

### DIFF
--- a/lib/promql.pegjs
+++ b/lib/promql.pegjs
@@ -41,7 +41,7 @@ FunctionCallBody
 
 FunctionCallArgs
   = FunctionCall
-  / args:(Expr ","?)* { return args.map(arg => arg[0]) }
+  / args:(Expr ","? _)* { return args.map(arg => arg[0]) }
 
 MatrixSelector
   = selector:VectorSelector '[' range:Duration* ']' { return { ...selector, range } }


### PR DESCRIPTION
This fixes parsing error when function arguments have whitespace after the comma.
